### PR TITLE
Fix configurazione di build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,9 +356,9 @@
 					</archive>
 				</configuration>
 			</plugin>			
- 
+--> 
 		</plugins>
- 		<resources>
+ <!--		<resources>
 			<resource>
 				<directory>src/main/resources</directory>
 				<excludes>


### PR DESCRIPTION
Nel pom manca il tag che chiude `<plugins>` per via di un commento. Con questa patch il progetto compila nuovamente.